### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - pypy3
   - 2.7
   - 2.7_with_system_site_packages
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ python:
 
 install:
   - python setup.py install
-  - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
-  - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then travis_retry pip install coverage; fi
+  - pip install coverage
   - coverage erase
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
   - pypy
-  - pypy3.3-5.5-alpha
+  - pypy3
   - 2.7
   - 2.7_with_system_site_packages
   - 3.3


### PR DESCRIPTION
## Reasons for dropping Python 3.3

* https://en.wikipedia.org/wiki/CPython#Version_history
* pip 10 will deprecate Python 3.3 support, pip 11 won't support it (https://github.com/pypa/pip/issues/3796)
* Very little PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796


---

Also test on latest version of PyPy3 rather than pinning on a given version. 

(At one  point, `PyPy3` wasn't the latest version available, but now it is.)